### PR TITLE
In-Game Editor and Unit persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+
+.units.db

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,6 +1848,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1871,6 +1884,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2165,6 +2187,18 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -2567,6 +2601,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,6 +2987,9 @@ dependencies = [
  "bevy",
  "bevy_egui",
  "raven-uxn",
+ "rusqlite",
+ "rusqlite-pool",
+ "rusqlite_migration",
  "ruxnasm",
  "zerocopy 0.8.18",
  "zerocopy-derive 0.8.18",
@@ -3022,6 +3068,17 @@ dependencies = [
  "bitflags 2.8.0",
  "libc",
  "redox_syscall 0.5.8",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4166,6 +4223,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.8.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
+name = "rusqlite-pool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5cb2126cde97e9a9f52bf9d69fa618458e9d9b034fbcae4ad91312494fdfa"
+dependencies = [
+ "crossbeam",
+ "rusqlite",
+]
+
+[[package]]
+name = "rusqlite_migration"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923b42e802f7dc20a0a6b5e097ba7c83fe4289da07e49156fecf6af08aa9cd1c"
+dependencies = [
+ "log",
+ "rusqlite",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4915,6 +5006,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ anyhow = "1.0.95"
 bevy = "0.15.1"
 bevy_egui = "0.33.0"
 raven-uxn = { package = "raven-uxn", git = "https://github.com/MarceColl/raven" }
+rusqlite = { version = "0.32.1", features = ["bundled"] }
+rusqlite-pool = "0.2.0"
+rusqlite_migration = "1.3.1"
 ruxnasm = "0.2.0"
 zerocopy = "0.8.18"
 zerocopy-derive = "0.8.18"

--- a/basic.tal
+++ b/basic.tal
@@ -1,11 +1,20 @@
 |00 @Command &move-vector $2 &attack-vector $2 &create-vector $2 &x $2 &y $2 &loop-vector $2
 |10 @Movement &move-decision-vector $2 &x $2 &y $2 &dir $1
 
+|000
+
+@Params
+    &stance 00
+    &patrol 00
+
 |100
     ;on-move-command .Command/move-vector DEO2
     ;on-attack .Command/attack-vector DEO2
     ;on-loop .Command/loop-vector DEO2
     ;on-move-decision .Movement/move-decision-vector DEO2
+BRK
+
+@on-interface-draw
 BRK
 
 @on-move-decision
@@ -29,3 +38,11 @@ BRK
 
 @signed-gth
 	DUP2 #8080 AND2 EQU ?&diff GTH JMP2r &diff GTH #00 NEQ JMP2r
+
+@stance-button-str
+    "Aggressive 00
+
+@patrol-button-str
+    "Patrol 00
+
+@BUTTON JMP2r

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,0 +1,160 @@
+use bevy::prelude::*;
+use crate::egui::{
+    style::{WidgetVisuals, Widgets},
+    Color32, Label, Sense, RichText, vec2, WidgetText,
+    FontDefinitions, FontData, FontFamily, Pos2, Stroke,
+    ComboBox, Window,
+};
+use bevy_egui::{egui, EguiContexts};
+
+use crate::bundles::UnitBundle;
+use crate::unit_spawn::SpawnUnitRequest;
+use crate::unit_repo::{UnitRepository, UnitDefinition};
+
+enum SandboxUIMode {
+    MainMenu,
+    CreateUnit {
+        unit_name: String,
+    },
+}
+
+#[derive(Resource)]
+struct SandboxState {
+    mode: SandboxUIMode,
+    selected_unit: Option<UnitDefinition>,
+    units: Vec<UnitDefinition>,
+    editor_open: bool,
+    current_code: String,
+    is_modified: bool,
+}
+
+impl SandboxState {
+    pub fn refresh_units(&mut self, repo: &UnitRepository) {
+        self.units = repo.get_units();
+    }
+}
+
+impl Default for SandboxState {
+    fn default() -> Self {
+        SandboxState {
+            mode: SandboxUIMode::MainMenu,
+            units: Vec::new(),
+            selected_unit: None,
+            editor_open: false,
+            current_code: "".to_string(),
+            is_modified: false,
+        }
+    }
+}
+
+fn draw_sandbox_ui(
+    mut context: EguiContexts,
+    mut spawn_events: EventWriter<SpawnUnitRequest>,
+    mut sandbox_state: ResMut<SandboxState>,
+    repo: Res<UnitRepository>,
+) {
+    egui::Window::new("Sandbox".to_string()).show(context.ctx_mut(), |ui| {
+        match &mut sandbox_state.mode {
+            SandboxUIMode::MainMenu => {
+                if ui.button("New Unit Type").clicked() {
+                    sandbox_state.mode = SandboxUIMode::CreateUnit {
+                        unit_name: String::new(),
+                    };
+                }
+
+                let mut selected_unit = sandbox_state.selected_unit.clone();
+                egui::ComboBox::from_label("Unit Type")
+                    .selected_text(sandbox_state.selected_unit.as_ref().map_or_else(|| "None".to_string(), |s| s.name.clone()))
+                    .show_ui(ui, |ui| {
+                        for ud in &sandbox_state.units {
+                            ui.selectable_value(&mut selected_unit, Some(ud.clone()), &ud.name);
+                        }
+                    }
+                );
+
+                if sandbox_state.selected_unit != selected_unit {
+                    sandbox_state.current_code = selected_unit.as_ref().unwrap().code.clone().unwrap_or_else(|| String::new());
+                    sandbox_state.selected_unit = selected_unit;
+                }
+
+                if ui.button("Create Unit").clicked() {
+                    spawn_events.send(SpawnUnitRequest {
+                        unit_id: 1,
+                        position: Vec2::new(10., 10.),
+                    });
+                }
+
+                if sandbox_state.editor_open {
+                    if ui.button("Close Code Editor").clicked() { sandbox_state.editor_open = false; }
+                } else {
+                    if ui.button("Open Code Editor").clicked() { sandbox_state.editor_open = true; }
+                }
+            },
+            SandboxUIMode::CreateUnit { unit_name: ref mut unit_name } => {
+                let name_to_create = unit_name.clone();
+                ui.add(egui::TextEdit::singleline(unit_name));
+
+                ui.with_layout(egui::Layout::left_to_right(egui::Align::TOP), |ui| {
+                    if ui.button("Create").clicked() {
+                        repo.new_unit_type(name_to_create);
+                        sandbox_state.refresh_units(&repo);
+                        sandbox_state.mode = SandboxUIMode::MainMenu;
+                    }
+
+                    if ui.button("Cancel").clicked() {
+                        sandbox_state.mode = SandboxUIMode::MainMenu;
+                    }
+                });
+            },
+        };
+    });
+}
+
+fn draw_editor_window(
+    mut context: EguiContexts,
+    mut spawn_events: EventWriter<SpawnUnitRequest>,
+    mut sandbox_state: ResMut<SandboxState>,
+    repo: Res<UnitRepository>,
+) {
+    if sandbox_state.editor_open {
+        egui::Window::new("Editor".to_string()).show(context.ctx_mut(), |ui| {
+            ui.with_layout(egui::Layout::left_to_right(egui::Align::TOP), |ui| {
+                if ui.button("Save").clicked() {
+                    repo.update_code_for_unit(
+                        sandbox_state.selected_unit.as_ref().unwrap().unit_id,
+                        sandbox_state.current_code.clone(),
+                    );
+                }
+                if ui.button("Compile").clicked() {}
+                if ui.button("Save & Compile").clicked() {}
+            });
+            ui.add(
+                egui::TextEdit::multiline(&mut sandbox_state.current_code)
+                    .code_editor()
+                    .desired_width(f32::INFINITY)
+                    .desired_rows(10)
+            );
+        });
+    }
+}
+
+fn initialize_sandbox_state(
+    mut sandbox_state: ResMut<SandboxState>,
+    repo: Res<UnitRepository>,
+) {
+    sandbox_state.refresh_units(&repo);
+}
+
+pub struct SandboxPlugin;
+
+impl Plugin for SandboxPlugin {
+    fn build(&self, app: &mut App) {
+        app
+            .insert_resource::<SandboxState>(SandboxState::default())
+            .add_systems(Startup, initialize_sandbox_state)
+            .add_systems(Update, (
+                draw_sandbox_ui,
+                draw_editor_window,
+            ));
+    }
+}

--- a/src/unit_repo.rs
+++ b/src/unit_repo.rs
@@ -1,0 +1,109 @@
+use bevy::prelude::*;
+use rusqlite::{params, Connection, OpenFlags};
+use rusqlite_migration::{Migrations, M};
+
+
+pub struct UnitRepoPlugin;
+
+#[derive(Resource)]
+pub struct UnitRepository {
+    pool: rusqlite_pool::ConnectionPool,
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct UnitDefinition {
+    pub unit_id: u64,
+    pub name: String,
+    pub code: Option<String>,
+}
+
+impl UnitRepository {
+    pub fn new(db_path: impl AsRef<std::path::Path> + Clone) -> Self {
+        UnitRepository {
+            pool: rusqlite_pool::ConnectionPool::new(10, || {
+                Connection::open_with_flags(db_path.clone(), OpenFlags::default())
+            }).unwrap(),
+        }
+    }
+
+    pub fn get_connection(&self) -> Option<rusqlite_pool::ConnectionHandle> {
+        self.pool.pop()
+    }
+
+    pub fn get_units(&self) -> Vec<UnitDefinition> {
+        let mut conn = self.pool.pop().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT u.unit_id, u.name, uv.code FROM units AS u LEFT JOIN unit_versions AS uv ON (u.current_version_id = uv.version_id)"
+        ).unwrap();
+
+        let rows = stmt.query_map([], |row| {
+            Ok(UnitDefinition {
+                unit_id: row.get(0)?,
+                name: row.get(1)?,
+                code: row.get(2)?,
+            })
+        }).unwrap();
+
+        let mut units = Vec::new();
+
+        for row in rows {
+            units.push(row.unwrap());
+        }
+
+        units
+    }
+
+    pub fn new_unit_type(&self, name: String) {
+        let mut conn = self.pool.pop().unwrap();
+        conn.execute("INSERT INTO units (name) VALUES (?1)", [name]).unwrap();
+    }
+
+    pub fn update_code_for_unit(&self, unit_id: u64, new_code: String) {
+        let mut conn = self.pool.pop().unwrap();
+        let version_id: u64 = conn.query_row(
+            "INSERT INTO unit_versions (unit_id, code) VALUES (?1, ?2) RETURNING version_id",
+            (unit_id, new_code),
+            |row| row.get(0),
+        ).unwrap();
+        conn.execute("UPDATE units SET current_version_id = ?1 WHERE unit_id = ?2", [version_id, unit_id]).unwrap();
+    }
+}
+
+fn run_migrations(conn: &mut Connection) {
+    let migrations = Migrations::new(vec![
+        M::up(r#"
+            -- Units table - stores basic unit information and tracks current version
+            CREATE TABLE units (
+                unit_id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                current_version_id INTEGER,
+                FOREIGN KEY (current_version_id) REFERENCES unit_versions (version_id)
+            );
+
+            -- Unit versions table - stores different code versions for each unit
+            CREATE TABLE unit_versions (
+                version_id INTEGER PRIMARY KEY,
+                unit_id INTEGER NOT NULL,
+                code TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (unit_id) REFERENCES units (unit_id)
+            );
+        "#),
+    ]);
+
+    migrations.to_latest(conn).unwrap();
+    println!("MIGRATIONS RAN");
+}
+
+fn setup_database(mut unit_repository: ResMut<UnitRepository>) {
+    let mut conn = unit_repository.get_connection().unwrap();
+    run_migrations(&mut conn);
+}
+
+impl Plugin for UnitRepoPlugin {
+    fn build(&self, app: &mut App) {
+        app
+            .insert_resource(UnitRepository::new("./units.db"))
+            .add_systems(Startup, setup_database);
+    }
+}

--- a/src/unit_spawn.rs
+++ b/src/unit_spawn.rs
@@ -1,0 +1,29 @@
+use bevy::prelude::*;
+use crate::bundles::UnitBundle;
+
+#[derive(Event)]
+pub struct SpawnUnitRequest {
+    pub unit_id: u64,
+    pub position: Vec2,
+}
+
+pub struct UnitSpawnPlugin;
+
+fn unit_spawner(
+    mut spawn_events: EventReader<SpawnUnitRequest>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    for request in spawn_events.read() {
+        commands.spawn(UnitBundle::new(request.position, &mut meshes, &mut materials));
+    }
+}
+
+impl Plugin for UnitSpawnPlugin {
+    fn build(&self, app: &mut App) {
+        app
+            .add_event::<SpawnUnitRequest>()
+            .add_systems(PostUpdate, unit_spawner);
+    }
+}


### PR DESCRIPTION
This patch introduces two main changes:
* A SQLite backed unit storage for persistent changes across restarts
  * Together with this a simple interface to create new unit types from the game
* An in-game code editor that supports editing, saving and (in the future) assembling
  * The saving and loading uses the unit storage mentioned above

Apart from that, this patch also does some very much needed refactor and moved some stuff into its own plugins. The sandbox stuff is already implemented as a plugin.